### PR TITLE
Added support to set name of node.

### DIFF
--- a/delay-topic-message.html
+++ b/delay-topic-message.html
@@ -8,6 +8,7 @@
 				required: true,
 				validate: RED.validators.number(),
 			},
+			name: {value:""},
 		},
 		inputs: 1,
 		outputs: 1,
@@ -19,6 +20,10 @@
 </script>
 
 <script type="text/html" data-template-name="delay-topic-message">
+    <div class="form-row">
+        <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
 	<div class="form-row">
 		<label for="node-input-delay"><i class="fa fa-clock-o"></i> Delay</label>
 		<input type="text" id="node-input-delay" placeholder="Delay in seconds">


### PR DESCRIPTION
This change allows to set the name of the node.
See:
![grafik](https://github.com/user-attachments/assets/564da0cc-0e2c-42a2-b395-e37493a056de)

First node is with default name (no value set).
Second node is with custom name defined.